### PR TITLE
Separate Kong Gateway and SSL

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -74,14 +74,12 @@ services:
       # The following two environment variables default to an insecure value (0.0.0.0)
       # according to the CIS Security test.
       - "${KONG_INBOUND_PROXY_LISTEN:-0.0.0.0}:8000:8000/tcp"
-      - "${KONG_INBOUND_SSL_PROXY_LISTEN:-0.0.0.0}:8443:8443/tcp"
       # Making them mandatory but undefined, like so would be backwards-breaking:
       # - "${KONG_INBOUND_PROXY_LISTEN?Missing inbound proxy host}:8000:8000/tcp"
       # - "${KONG_INBOUND_SSL_PROXY_LISTEN?Missing inbound proxy ssl host}:8443:8443/tcp"
       # Alternative is deactivating check 5.13 in the security bench, if we consider Kong's own config to be enough security here
 
       - "127.0.0.1:8001:8001/tcp"
-      - "127.0.0.1:8444:8444/tcp"
       - "127.0.0.1:8002:8002/tcp"
     healthcheck:
       test: [ "CMD", "kong", "health" ]


### PR DESCRIPTION
This fork is used exclusively for [hashicorp-aws](https://github.com/QubitPi/hashicorp-aws/pull/104/files) which assumes app and SSL are separate for better team work. It is, therefore, customized to run entire compose without SSL